### PR TITLE
fix namespacing issues

### DIFF
--- a/app/services/generation-interface.js
+++ b/app/services/generation-interface.js
@@ -63,9 +63,9 @@ export default Ember.Service.extend({
     }
 
     // Stores functions in array to avoid lookups in loop
-    let generatorFuncs = this.get('generatorFuncs');
+    let paths = this.get('generatorPaths');
     let rows = this.get('rows');
-    let generatorFuncsLength = generatorFuncs.length;
+    let pathsLength = paths.length;
 
     for (let i = rows; i--;) {
       if (i % 100 === 0) {
@@ -73,8 +73,8 @@ export default Ember.Service.extend({
       }
 
       let row = [];
-      for (let i = 0; i < generatorFuncsLength; i++) {
-        row[i] = generatorFuncs[i]();
+      for (let i = 0; i < pathsLength; i++) {
+        row[i] = faker[paths[i][0]][paths[i][1]]();
       }
       array.push(row);
     }
@@ -132,18 +132,6 @@ export default Ember.Service.extend({
 
   // CPS
   headers: computed.mapBy('generators.[]', 'name'),
-
-  /**
-   *Returns faker methods from generator paths
-   * @type { Array }
-   */
-  generatorFuncs: computed('generatorPaths.[]', {
-    get() {
-      return this.get('generatorPaths').map(path =>{
-        return faker[path[0]][path[1]];
-      });
-    }
-  }),
 
   /**
    * Paths for generators

--- a/vendor/workers/gen-data.js
+++ b/vendor/workers/gen-data.js
@@ -2,15 +2,14 @@ importScripts('/assets/faker.js');
 importScripts('/assets/papaparse.js');
 
 function generateData(paths, rows, headers) {
-  var generatorFuncs = buildGeneratorFunctions(paths);
-  var generatorFuncsLength = generatorFuncs.length;
+  var pathsLength = paths.length;
 
   var arr = new Array(rows);
 
   for (var i = 0; i < rows; i++) {
     var row = [];
-    for(var j = 0; j < generatorFuncsLength; j++) {
-      row[j] = generatorFuncs[j]();
+    for(var j = 0; j < pathsLength; j++) {
+      row[j] = faker[paths[j][0]][paths[j][1]]();
     }
     arr[i] = row;
   }
@@ -20,13 +19,6 @@ function generateData(paths, rows, headers) {
   }
   return arr;
 }
-
-function buildGeneratorFunctions(paths) {
-  return paths.map(function(path) {
-    return faker[path[0]][path[1]];
-  });
-}
-
 
 self.addEventListener('message', function(e) {
   var csvArray = generateData(e.data.paths, e.data.rows, e.data.headers);


### PR DESCRIPTION
Fixes issues where faker functions we're being stored in arr, and calling them caused errors since the functions we're using other faker functions example

`faker.random.uuid ` uses `faker.random.number` internally which caused error when not found
